### PR TITLE
Added env vars to turn on/off topology mapper and benchmark scoring wait as features

### DIFF
--- a/sre/Makefile
+++ b/sre/Makefile
@@ -115,6 +115,7 @@ ifeq ($(BENCHMARK_SCORING),true)
 	ansible-playbook -v base.yaml --tags "pre_fault_removal"
 else
 	ansible-playbook -v base.yaml --tags "pre_fault_removal" --skip-tags "no_scoring"
+endif
 ifeq ($(IS_DEBUG_SCENARIO),true)
 	ansible-playbook -v base.yaml --tags "incident_$(INCIDENT_NUMBER)" \
 		--extra-vars "debug=true" \

--- a/sre/Makefile
+++ b/sre/Makefile
@@ -11,6 +11,7 @@ FINOPS_SCENARIOS := 37
 HOTEL_RESERVATION_SCENARIOS := 102
 
 ENABLE_TOPOLOGY_MAPPER ?= false
+BENCHMARK_SCORING ?= false
 
 IS_DEBUG_SCENARIO ?= true
 IS_FINOPS_SCENARIO := $(shell echo "$(FINOPS_SCENARIOS)" | grep -w "$(INCIDENT_NUMBER)" > /dev/null && echo "true" || echo "false")
@@ -110,7 +111,10 @@ endif
 
 .PHONY: remove_incident_fault
 remove_incident_fault: ## Removes the fault used in a specific incident
+ifeq ($(BENCHMARK_SCORING),true)
 	ansible-playbook -v base.yaml --tags "pre_fault_removal"
+else
+	ansible-playbook -v base.yaml --tags "pre_fault_removal" --skip-tags "no_scoring"
 ifeq ($(IS_DEBUG_SCENARIO),true)
 	ansible-playbook -v base.yaml --tags "incident_$(INCIDENT_NUMBER)" \
 		--extra-vars "debug=true" \

--- a/sre/Makefile
+++ b/sre/Makefile
@@ -103,19 +103,11 @@ else
 		--extra-vars "incident_number=$(INCIDENT_NUMBER)" \
 		--extra-vars "sample_application=$(SAMPLE_APPLICATION)"
 endif
-ifeq ($(ENABLE_TOPOLOGY_MAPPER),true)
 	ansible-playbook -v base.yaml --tags "post_fault_injection" 
-else
-	ansible-playbook -v base.yaml --tags "post_fault_injection" --skip-tags "topology_mapper"
-endif
 
 .PHONY: remove_incident_fault
 remove_incident_fault: ## Removes the fault used in a specific incident
-ifeq ($(BENCHMARK_SCORING),true)
 	ansible-playbook -v base.yaml --tags "pre_fault_removal"
-else
-	ansible-playbook -v base.yaml --tags "pre_fault_removal" --skip-tags "no_scoring"
-endif
 ifeq ($(IS_DEBUG_SCENARIO),true)
 	ansible-playbook -v base.yaml --tags "incident_$(INCIDENT_NUMBER)" \
 		--extra-vars "debug=true" \

--- a/sre/Makefile
+++ b/sre/Makefile
@@ -10,6 +10,8 @@ NUMBER_OF_RUNS = 1
 FINOPS_SCENARIOS := 37
 HOTEL_RESERVATION_SCENARIOS := 102
 
+ENABLE_TOPOLOGY_MAPPER ?= false
+
 IS_DEBUG_SCENARIO ?= true
 IS_FINOPS_SCENARIO := $(shell echo "$(FINOPS_SCENARIOS)" | grep -w "$(INCIDENT_NUMBER)" > /dev/null && echo "true" || echo "false")
 IS_HOTEL_RESERVATION_SCENARIO := $(shell echo "$(HOTEL_RESERVATION_SCENARIOS)" | grep -w "$(INCIDENT_NUMBER)" > /dev/null && echo "true" || echo "false")
@@ -100,7 +102,11 @@ else
 		--extra-vars "incident_number=$(INCIDENT_NUMBER)" \
 		--extra-vars "sample_application=$(SAMPLE_APPLICATION)"
 endif
-	ansible-playbook -v base.yaml --tags "post_fault_injection"
+ifeq ($(ENABLE_TOPOLOGY_MAPPER),true)
+	ansible-playbook -v base.yaml --tags "post_fault_injection" 
+else
+	ansible-playbook -v base.yaml --tags "post_fault_injection" --skip-tags "topology_mapper"
+endif
 
 .PHONY: remove_incident_fault
 remove_incident_fault: ## Removes the fault used in a specific incident

--- a/sre/README.md
+++ b/sre/README.md
@@ -4,7 +4,7 @@ Two new environment variables are introduced to expedite development and testing
 To turn off any topology mapper-related commands in the ansible playbooks, add `ENABLE_TOPOLOGY=false` before your `make` command.
 For example:
 ```bash
-INCIDENT_NUMBER=1 ENABLE_TOPOLOGY_MAPPER=false make remove_incident_fault
+INCIDENT_NUMBER=1 ENABLE_TOPOLOGY_MAPPER=false make inject_incident_fault
 ```
 
 To turn off the mandatory 600-second wait for benchmark scoring, add `BENCHMARK_SCORING=false` before your `make` command.

--- a/sre/README.md
+++ b/sre/README.md
@@ -1,3 +1,20 @@
+# Turn on/off topology mapper and benchmark scoring
+Two new environment variables are introduced to expedite development and testing.
+
+To turn off any topology mapper-related commands in the ansible playbooks, add `ENABLE_TOPOLOGY=false` before your `make` command.
+For example:
+```bash
+INCIDENT_NUMBER=1 ENABLE_TOPOLOGY_MAPPER=false make remove_incident_fault
+```
+
+To turn off the mandatory 600-second wait for benchmark scoring, add `BENCHMARK_SCORING=false` before your `make` command.
+For example:
+```bash
+INCIDENT_NUMBER=1 BENCHMARK_SCORING=true make remove_incident_fault
+```
+
+By default, both environment variables will have `false` as the default value in the Makefile.
+
 # ITBench for Site Reliability Engineering (SRE) and Financial Operations (FinOps)
 
 **[Paper](#paper) | [Incident Scenarios](./docs/incident_scenarios.md) | [Tools](./docs/tools.md) | [Maintainers](#maintainers)**

--- a/sre/group_vars/fault_injection.yaml
+++ b/sre/group_vars/fault_injection.yaml
@@ -14,6 +14,8 @@ chaos_mesh_version_number: "2.7.0"
 # Default fault injection-removal values
 is_fault_injection: false
 is_fault_removal: false
+is_topology_mapper_enabled: false
+is_benchmark_scoring: false
 
 # Chaos Mesh-based Faults
 is_install_chaos_mesh: false

--- a/sre/local_cluster/kind-config.yaml
+++ b/sre/local_cluster/kind-config.yaml
@@ -3,7 +3,3 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-cluster
 nodes:
   - role: control-plane
-containerdConfigPatches:
-  - |
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-      endpoint = ["http://172.17.0.1:5000"]

--- a/sre/local_cluster/kind-config.yaml
+++ b/sre/local_cluster/kind-config.yaml
@@ -3,3 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-cluster
 nodes:
   - role: control-plane
+containerdConfigPatches:
+  - |
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["http://172.17.0.1:5000"]

--- a/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
+++ b/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
@@ -34,22 +34,26 @@
   retries: 10
   delay: 5
   until: topology_responses is succeeded
-  tags: [ post_fault_injection, topology_mapper ]
+  tags: 
+    - post_fault_injection
+  when: is_topology_mapper_enabled
 
 - name: Ensure topology_information directory exists
   ansible.builtin.file:
     path: "/runner/topology_information"
     state: directory
-  tags: [ post_fault_injection, topology_mapper ]
-  when: run_uuid is defined and scenario_number is defined and run_number is defined
+  tags: 
+    - post_fault_injection
+  when: is_topology_mapper_enabled and run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Copy content to file(s)
   ansible.builtin.copy:
     content: "{{ item.content | to_json }}"
     dest: "/runner/topology_information/start_{{ item.item }}_{{now(utc=true,fmt='%Y-%m-%dT%H:%M:%S.%f')}}.json"
   with_items: "{{ topology_responses.results }}"
-  tags: [ post_fault_injection, topology_mapper ]
-  when: run_uuid is defined and scenario_number is defined and run_number is defined
+  tags: 
+    - post_fault_injection
+  when: is_topology_mapper_enabled and run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Upload structured-unstructured outputs to S3
   community.aws.s3_sync:
@@ -57,5 +61,6 @@
     file_root: "/runner/topology_information"
     key_prefix: "{{ sre_agent_name__version_number }}/{{run_uuid}}/{{scenario_number}}/{{run_number}}/topology_information"
     region: "us-east-2"
-  tags: [ post_fault_injection, topology_mapper ]
-  when: run_uuid is defined and scenario_number is defined and run_number is defined
+  tags: 
+    - post_fault_injection
+  when: is_topology_mapper_enabled and run_uuid is defined and scenario_number is defined and run_number is defined

--- a/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
+++ b/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
@@ -34,17 +34,13 @@
   retries: 10
   delay: 5
   until: topology_responses is succeeded
-  tags:
-    - post_fault_injection
-    - topology_mapper
+  tags: [ post_fault_injection, topology_mapper ]
 
 - name: Ensure topology_information directory exists
   ansible.builtin.file:
     path: "/runner/topology_information"
     state: directory
-  tags:
-    - post_fault_injection
-    - topology_mapper
+  tags: [ post_fault_injection, topology_mapper ]
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Copy content to file(s)
@@ -52,9 +48,7 @@
     content: "{{ item.content | to_json }}"
     dest: "/runner/topology_information/start_{{ item.item }}_{{now(utc=true,fmt='%Y-%m-%dT%H:%M:%S.%f')}}.json"
   with_items: "{{ topology_responses.results }}"
-  tags:
-    - post_fault_injection
-    - topology_mapper
+  tags: [ post_fault_injection, topology_mapper ]
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Upload structured-unstructured outputs to S3
@@ -63,7 +57,5 @@
     file_root: "/runner/topology_information"
     key_prefix: "{{ sre_agent_name__version_number }}/{{run_uuid}}/{{scenario_number}}/{{run_number}}/topology_information"
     region: "us-east-2"
-  tags:
-    - post_fault_injection
-    - topology_mapper
+  tags: [ post_fault_injection, topology_mapper ]
   when: run_uuid is defined and scenario_number is defined and run_number is defined

--- a/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
+++ b/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
@@ -17,23 +17,9 @@
   tags:
     - post_fault_injection
 
-- name: Call the Topology APIs
-  uri:
-    url: "{{ topology_url }}/{{ item }}"
-    method: GET
-    return_content: yes
-    body_format: json
-    headers:
-      Content-Type: "application/json"
-  with_items:
-    - "nodes"
-    - "edges"
-    - "graph"
-    - "events"
-  register: topology_responses
-  retries: 10
-  delay: 5
-  until: topology_responses is succeeded
+- name: Call the Topology APIs (deprecated with wait 1 second)
+  ansible.builtin.pause:
+    seconds: 1
   tags:
     - post_fault_injection
 

--- a/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
+++ b/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
@@ -17,9 +17,23 @@
   tags:
     - post_fault_injection
 
-- name: Call the Topology APIs (deprecated with wait 1 second)
-  ansible.builtin.pause:
-    seconds: 1
+- name: Call the Topology APIs
+  uri:
+    url: "{{ topology_url }}/{{ item }}"
+    method: GET
+    return_content: yes
+    body_format: json
+    headers:
+      Content-Type: "application/json"
+  with_items:
+    - "nodes"
+    - "edges"
+    - "graph"
+    - "events"
+  register: topology_responses
+  retries: 10
+  delay: 5
+  until: topology_responses is succeeded
   tags:
     - post_fault_injection
 

--- a/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
+++ b/sre/roles/post_fault_injection/tasks/record_topology_information.yaml
@@ -36,6 +36,7 @@
   until: topology_responses is succeeded
   tags:
     - post_fault_injection
+    - topology_mapper
 
 - name: Ensure topology_information directory exists
   ansible.builtin.file:
@@ -43,6 +44,7 @@
     state: directory
   tags:
     - post_fault_injection
+    - topology_mapper
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Copy content to file(s)
@@ -52,6 +54,7 @@
   with_items: "{{ topology_responses.results }}"
   tags:
     - post_fault_injection
+    - topology_mapper
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Upload structured-unstructured outputs to S3
@@ -62,4 +65,5 @@
     region: "us-east-2"
   tags:
     - post_fault_injection
+    - topology_mapper
   when: run_uuid is defined and scenario_number is defined and run_number is defined

--- a/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
+++ b/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
@@ -7,13 +7,9 @@
     release_namespace: "{{ topology_mapper_namespace_project_name }}"
     state: present
     wait: true
-  tags:
-    - post_fault_injection
-    - topology_mapper
+  tags: [ post_fault_injection, topology_mapper ]
 
 - name: Pause for 5 minutes for the topology to be available
   ansible.builtin.pause:
     minutes: 5
-  tags:
-    - post_fault_injection
-    - topology_mapper
+  tags: [ post_fault_injection, topology_mapper ]

--- a/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
+++ b/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
@@ -7,9 +7,13 @@
     release_namespace: "{{ topology_mapper_namespace_project_name }}"
     state: present
     wait: true
-  tags: [ post_fault_injection, topology_mapper ]
+  tags: 
+    - post_fault_injection
+  when: is_topology_mapper_enabled
 
 - name: Pause for 5 minutes for the topology to be available
   ansible.builtin.pause:
     minutes: 5
-  tags: [ post_fault_injection, topology_mapper ]
+  tags: 
+    - post_fault_injection
+  when: is_topology_mapper_enabled

--- a/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
+++ b/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
@@ -1,17 +1,11 @@
-- name: Deploy Saurabh's Kubernetes topology mapper
-  kubernetes.core.helm:
-    name: "{{ topology_mapper_installation_name }}"
-    kubeconfig_path: "{{ kubeconfig }}"
-    chart_ref: tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper
-    dependency_update: true
-    release_namespace: "{{ topology_mapper_namespace_project_name }}"
-    state: present
-    wait: true
+- name: Deploy Saurabh's Kubernetes topology mapper (deprecated as wait 1 second)
+  ansible.builtin.pause:
+    seconds: 1
   tags:
     - post_fault_injection
 
-- name: Pause for 5 minutes for the topology to be available
+- name: Pause for 5 minutes for the topology to be available (deprecated as wait 1 second)
   ansible.builtin.pause:
-    minutes: 5
+    seconds: 1
   tags:
     - post_fault_injection

--- a/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
+++ b/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
@@ -9,9 +9,11 @@
     wait: true
   tags:
     - post_fault_injection
+    - topology_mapper
 
 - name: Pause for 5 minutes for the topology to be available
   ansible.builtin.pause:
     minutes: 5
   tags:
     - post_fault_injection
+    - topology_mapper

--- a/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
+++ b/sre/roles/post_fault_injection/tasks/set_up_topology_mapper.yaml
@@ -1,11 +1,17 @@
-- name: Deploy Saurabh's Kubernetes topology mapper (deprecated as wait 1 second)
-  ansible.builtin.pause:
-    seconds: 1
+- name: Deploy Saurabh's Kubernetes topology mapper
+  kubernetes.core.helm:
+    name: "{{ topology_mapper_installation_name }}"
+    kubeconfig_path: "{{ kubeconfig }}"
+    chart_ref: tools/kubernetes-topology-mapper/charts/kubernetes-topology-mapper
+    dependency_update: true
+    release_namespace: "{{ topology_mapper_namespace_project_name }}"
+    state: present
+    wait: true
   tags:
     - post_fault_injection
 
-- name: Pause for 5 minutes for the topology to be available (deprecated as wait 1 second)
+- name: Pause for 5 minutes for the topology to be available
   ansible.builtin.pause:
-    seconds: 1
+    minutes: 5
   tags:
     - post_fault_injection

--- a/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
+++ b/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
@@ -2,6 +2,6 @@
 - name: Pause for 600 seconds pre-fault removal for alert recording
   pause:
     seconds: 600
-  when: not sre_bench_runner
-  tags: [pre_fault_removal, no_scoring]
+  when: not sre_bench_runner and not is_benchmark_scoring 
+  tags: pre_fault_removal
 

--- a/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
+++ b/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
@@ -1,7 +1,7 @@
 ---
-- name: Pause for 600 seconds pre-fault removal for alert recording (deprecated as wait 1 second)
+- name: Pause for 600 seconds pre-fault removal for alert recording
   pause:
-    seconds: 1
+    seconds: 600
   when: not sre_bench_runner
   tags:
     - pre_fault_removal

--- a/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
+++ b/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
@@ -3,6 +3,5 @@
   pause:
     seconds: 600
   when: not sre_bench_runner
-  tags:
-    - pre_fault_removal
+  tags: [pre_fault_removal, no_scoring]
 

--- a/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
+++ b/sre/roles/pre_fault_removal/tasks/pause_for_alert_recording_post_agent_run.yaml
@@ -1,7 +1,7 @@
 ---
-- name: Pause for 600 seconds pre-fault removal for alert recording
+- name: Pause for 600 seconds pre-fault removal for alert recording (deprecated as wait 1 second)
   pause:
-    seconds: 600
+    seconds: 1
   when: not sre_bench_runner
   tags:
     - pre_fault_removal

--- a/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
+++ b/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
@@ -34,17 +34,13 @@
   retries: 10
   delay: 5
   until: topology_responses is succeeded
-  tags:
-    - pre_fault_removal
-    - topology_mapper
+  tags: [ pre_fault_removal, topology_mapper ]
 
 - name: Ensure topology_information directory exists
   ansible.builtin.file:
     path: "/runner/topology_information"
     state: directory
-  tags:
-    - pre_fault_removal
-    - topology_mapper
+  tags: [ pre_fault_removal, topology_mapper ]
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Copy content to file(s)
@@ -52,9 +48,7 @@
     content: "{{ item.content | to_json }}"
     dest: "/runner/topology_information/end_{{ item.item }}_{{now(utc=true,fmt='%Y-%m-%dT%H:%M:%S.%f')}}.json"
   with_items: "{{ topology_responses.results }}"
-  tags:
-    - pre_fault_removal
-    - topology_mapper
+  tags: [ pre_fault_removal, topology_mapper ]
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Upload structured-unstructured outputs to S3
@@ -63,7 +57,5 @@
     file_root: "/runner/topology_information"
     key_prefix: "{{ sre_agent_name__version_number }}/{{run_uuid}}/{{scenario_number}}/{{run_number}}/topology_information"
     region: "us-east-2"
-  tags:
-    - pre_fault_removal
-    - topology_mapper
+  tags: [ pre_fault_removal, topology_mapper ]
   when: run_uuid is defined and scenario_number is defined and run_number is defined

--- a/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
+++ b/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
@@ -36,6 +36,7 @@
   until: topology_responses is succeeded
   tags:
     - pre_fault_removal
+    - topology_mapper
 
 - name: Ensure topology_information directory exists
   ansible.builtin.file:
@@ -43,6 +44,7 @@
     state: directory
   tags:
     - pre_fault_removal
+    - topology_mapper
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Copy content to file(s)
@@ -52,6 +54,7 @@
   with_items: "{{ topology_responses.results }}"
   tags:
     - pre_fault_removal
+    - topology_mapper
   when: run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Upload structured-unstructured outputs to S3
@@ -62,4 +65,5 @@
     region: "us-east-2"
   tags:
     - pre_fault_removal
+    - topology_mapper
   when: run_uuid is defined and scenario_number is defined and run_number is defined

--- a/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
+++ b/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
@@ -17,9 +17,23 @@
   tags:
     - pre_fault_removal
 
-- name: Call the Topology APIs (deprecated with wait 1 second)
-  ansible.builtin.pause:
-    seconds: 1
+- name: Call the Topology APIs
+  uri:
+    url: "{{ topology_url }}/{{ item }}"
+    method: GET
+    return_content: yes
+    body_format: json
+    headers:
+      Content-Type: "application/json"
+  with_items:
+    - "nodes"
+    - "edges"
+    - "graph"
+    - "events"
+  register: topology_responses
+  retries: 10
+  delay: 5
+  until: topology_responses is succeeded
   tags:
     - pre_fault_removal
 

--- a/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
+++ b/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
@@ -17,23 +17,9 @@
   tags:
     - pre_fault_removal
 
-- name: Call the Topology APIs
-  uri:
-    url: "{{ topology_url }}/{{ item }}"
-    method: GET
-    return_content: yes
-    body_format: json
-    headers:
-      Content-Type: "application/json"
-  with_items:
-    - "nodes"
-    - "edges"
-    - "graph"
-    - "events"
-  register: topology_responses
-  retries: 10
-  delay: 5
-  until: topology_responses is succeeded
+- name: Call the Topology APIs (deprecated with wait 1 second)
+  ansible.builtin.pause:
+    seconds: 1
   tags:
     - pre_fault_removal
 

--- a/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
+++ b/sre/roles/pre_fault_removal/tasks/record_topology_information.yaml
@@ -34,22 +34,25 @@
   retries: 10
   delay: 5
   until: topology_responses is succeeded
-  tags: [ pre_fault_removal, topology_mapper ]
+  tags: 
+    - pre_fault_removal
 
 - name: Ensure topology_information directory exists
   ansible.builtin.file:
     path: "/runner/topology_information"
     state: directory
-  tags: [ pre_fault_removal, topology_mapper ]
-  when: run_uuid is defined and scenario_number is defined and run_number is defined
+  tags: 
+    - pre_fault_removal
+  when: is_topology_mapper_enabled and run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Copy content to file(s)
   ansible.builtin.copy:
     content: "{{ item.content | to_json }}"
     dest: "/runner/topology_information/end_{{ item.item }}_{{now(utc=true,fmt='%Y-%m-%dT%H:%M:%S.%f')}}.json"
   with_items: "{{ topology_responses.results }}"
-  tags: [ pre_fault_removal, topology_mapper ]
-  when: run_uuid is defined and scenario_number is defined and run_number is defined
+  tags: 
+    - pre_fault_removal
+  when: is_topology_mapper_enabled and run_uuid is defined and scenario_number is defined and run_number is defined
 
 - name: Upload structured-unstructured outputs to S3
   community.aws.s3_sync:
@@ -57,5 +60,6 @@
     file_root: "/runner/topology_information"
     key_prefix: "{{ sre_agent_name__version_number }}/{{run_uuid}}/{{scenario_number}}/{{run_number}}/topology_information"
     region: "us-east-2"
-  tags: [ pre_fault_removal, topology_mapper ]
-  when: run_uuid is defined and scenario_number is defined and run_number is defined
+  tags: 
+    - pre_fault_removal
+  when: is_topology_mapper_enabled and run_uuid is defined and scenario_number is defined and run_number is defined


### PR DESCRIPTION
Now all topology mapper commands in the ansible files will not take effect. They are replaced with `sleep 1`. 